### PR TITLE
Staff over Admins

### DIFF
--- a/Language/English/English.xml
+++ b/Language/English/English.xml
@@ -173,7 +173,7 @@
   <chatRequestDuel>Request Duel</chatRequestDuel>
   <chatIgnoreUser>Ignore User</chatIgnoreUser>
   <chatViewProfile>View Profile</chatViewProfile>
-  <chatBtnAdmin> Admins</chatBtnAdmin>
+  <chatBtnAdmin> Staff</chatBtnAdmin>
  <chatBtnTeam> Team</chatBtnTeam>
  <chatBtnFriend> Friends</chatBtnFriend>
   <chatBtnUser> User Search</chatBtnUser>


### PR DESCRIPTION
DN has "Admins"
DevPro has something else, in this case I'm picking the word "Staff". DevPro has two classes where DN has 1. A reoccurring problem in the English chats is a confusion of the ability and focus's  of [Dev]s and [Mod]s with DN Admins. Thinking they can adjust game state, provide game rulings, or are specific specific to DevPro. Checkmate and I have [Dev] tags but do development else where that gets drawn back into DevPro down the line. "Staff" is a better translation over "Admins" and avoids jargon and connotations attached to DN.
