### PR TITLE
Msg Box Kick/Ban Fixed + Bug text == null fixed

### DIFF
--- a/Config/Configuration.cs
+++ b/Config/Configuration.cs
@@ -90,7 +90,7 @@ namespace DevProLauncher.Config
 
         public SerializableColor ChatBGColor = new SerializableColor(Color.White);
         public SerializableColor NormalTextColor = new SerializableColor(Color.Black);
-        public SerializableColor Level99Color = new SerializableColor(Color.Green);
+        public SerializableColor BotColor = new SerializableColor(Color.Green);
         public SerializableColor Level4Color = new SerializableColor(Color.Red);
         public SerializableColor Level3Color = new SerializableColor(Color.Blue);
         public SerializableColor Level2Color = new SerializableColor(Color.IndianRed);

--- a/Config/LanguageInfo.cs
+++ b/Config/LanguageInfo.cs
@@ -305,9 +305,9 @@ namespace DevProLauncher.Config
 
         public string chatoptionsLblChatBackground = "Chat Background";
         public string chatoptionsLblNormalText = "Normal Text";
-        public string chatoptionsLblLevel99 = "Level 99";
+        public string chatoptionsLblLevel98 = "Bot";
         public string chatoptionsLblLevel2 = "Level 2";
-        public string chatoptionsLblLevel1 = "Level 1";
+        public string chatoptionsLblLevel1 = "Helper";
         public string chatoptionsLblNormalUser = "Normal Username";
         public string chatoptionsLblServerMessages = "Server Message";
         public string chatoptionsLblMeMessage = "/Me Message";

--- a/Helpers/ChatHelper.cs
+++ b/Helpers/ChatHelper.cs
@@ -215,6 +215,8 @@ namespace DevProLauncher.Helpers
         {
             window.Select(window.TextLength, 0);
             window.SelectionColor = color;
+            if (text == null)
+                text = "";
             window.AppendText(text);
         }
 

--- a/Network/ChatClient.cs
+++ b/Network/ChatClient.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using DevProLauncher.Network.Data;
 using ServiceStack.Text;
 using DevProLauncher.Windows.Enums;
+using System.Diagnostics;
 
 namespace DevProLauncher.Network
 {
@@ -330,9 +331,16 @@ namespace DevProLauncher.Network
                     if (LoginReply != null)
                         LoginReply(e.Packet, null);
                     break;
-                case DevClientPackets.Banned: 
-                    //ServerKickBanMessage = Encoding.UTF8.GetString(e.Reader.ReadBytes(e.Raw.Length));
-                    MessageBox.Show(Encoding.UTF8.GetString(e.Reader.ReadBytes(e.Raw.Length)), "Server", MessageBoxButtons.OK);
+                case DevClientPackets.Banned:
+                    ServerKickBanMessage = Encoding.UTF8.GetString(e.Raw);
+                    if (MessageBox.Show(ServerKickBanMessage, "Server", MessageBoxButtons.OK) == DialogResult.OK)
+                    {
+                        Application.Exit();
+                    }
+                    else
+                    {                        
+                        Application.Exit();
+                    }
                     break;
                 case DevClientPackets.RegisterAccept:                
                     if (RegisterReply != null)
@@ -530,7 +538,7 @@ namespace DevProLauncher.Network
                         UpdateRoomStatus(Encoding.UTF8.GetString(e.Reader.ReadBytes(e.Raw.Length)));
                     break;
                 case DevClientPackets.Kicked:
-                    ServerKickBanMessage = Encoding.UTF8.GetString(e.Raw);
+                    ServerKickBanMessage = Encoding.UTF8.GetString(e.Raw) + "\n\r Do you want to restart DevPro ?";
                     break;
                 default:                
                     if (OnFatalError != null)

--- a/Network/ChatClient.cs
+++ b/Network/ChatClient.cs
@@ -81,7 +81,7 @@ namespace DevProLauncher.Network
         public UserDuelRequest MatchStart;
 
         public string ServerKickBanMessage;
-
+        public bool IsUserBanned = false;
 
         public ChatClient()
         {
@@ -332,7 +332,7 @@ namespace DevProLauncher.Network
                         LoginReply(e.Packet, null);
                     break;
                 case DevClientPackets.Banned:
-                    Program.banned = true;                   
+                    IsUserBanned = true;                   
                     ServerKickBanMessage = Encoding.UTF8.GetString(e.Raw);
                     MessageBox.Show(ServerKickBanMessage, "Server", MessageBoxButtons.OK);
                     Application.Exit();                  

--- a/Network/ChatClient.cs
+++ b/Network/ChatClient.cs
@@ -332,15 +332,10 @@ namespace DevProLauncher.Network
                         LoginReply(e.Packet, null);
                     break;
                 case DevClientPackets.Banned:
+                    Program.banned = true;                   
                     ServerKickBanMessage = Encoding.UTF8.GetString(e.Raw);
-                    if (MessageBox.Show(ServerKickBanMessage, "Server", MessageBoxButtons.OK) == DialogResult.OK)
-                    {
-                        Application.Exit();
-                    }
-                    else
-                    {                        
-                        Application.Exit();
-                    }
+                    MessageBox.Show(ServerKickBanMessage, "Server", MessageBoxButtons.OK);
+                    Application.Exit();                  
                     break;
                 case DevClientPackets.RegisterAccept:                
                     if (RegisterReply != null)

--- a/Network/Data/ChatMessage.cs
+++ b/Network/Data/ChatMessage.cs
@@ -64,8 +64,8 @@ namespace DevProLauncher.Network.Data
                     return Program.Config.Level3Color.ToColor();
                 case 4:
                     return Program.Config.Level4Color.ToColor();
-                case 99:
-                    return Program.Config.Level99Color.ToColor();
+                case 98:
+                    return Program.Config.BotColor.ToColor();
             }
 
             return Program.Config.Level0Color.ToColor();
@@ -85,8 +85,8 @@ namespace DevProLauncher.Network.Data
                     return new SolidBrush(Program.Config.Level3Color.ToColor());
                 case 4:
                     return new SolidBrush(Program.Config.Level4Color.ToColor());
-                case 99:
-                    return new SolidBrush(Program.Config.Level99Color.ToColor());
+                case 98:
+                    return new SolidBrush(Program.Config.BotColor.ToColor());
             }
 
             return new SolidBrush(Program.Config.Level0Color.ToColor());

--- a/Program.cs
+++ b/Program.cs
@@ -68,13 +68,11 @@ namespace DevProLauncher
 #endif
             }
             else MessageBox.Show("An internet connection is required to play online.");
-/*
 #if DEBUG
             Config.ServerAddress = "127.0.0.1";
             Config.ChatPort = 8933;
             Server = new ServerInfo("DevPro", "127.0.0.1", 3333);
 #endif
-*/
             MainForm = new MainFrm();
             Application.Run(MainForm);
         }

--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,8 @@ namespace DevProLauncher
         public static Dictionary<string,ServerInfo> CheckmateServerList = new Dictionary<string,ServerInfo>();
         public static Random Rand = new Random();
 
+        public static bool banned = false;
+
         [STAThread]
         static void Main()
         {

--- a/Program.cs
+++ b/Program.cs
@@ -31,9 +31,7 @@ namespace DevProLauncher
         public static MainFrm MainForm;
         public static ServerInfo Server;
         public static Dictionary<string,ServerInfo> CheckmateServerList = new Dictionary<string,ServerInfo>();
-        public static Random Rand = new Random();
-
-        public static bool banned = false;
+        public static Random Rand = new Random();        
 
         [STAThread]
         static void Main()

--- a/Windows/Chat_frm.Designer.cs
+++ b/Windows/Chat_frm.Designer.cs
@@ -37,8 +37,10 @@ namespace DevProLauncher.Windows
             this.ChatInput = new System.Windows.Forms.TextBox();
             this.ChannelListBtn = new System.Windows.Forms.Button();
             this.LeaveBtn = new System.Windows.Forms.Button();
-            this.ChannelTabs = new DevProLauncher.Windows.Components.FixedTabControl();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel6 = new System.Windows.Forms.TableLayoutPanel();
+            this.UserSearch = new System.Windows.Forms.TextBox();
+            this.ChannelTabs = new DevProLauncher.Windows.Components.FixedTabControl();
             this.UsersControl = new DevProLauncher.Windows.Components.FixedTabControl();
             this.UsersTab = new System.Windows.Forms.TabPage();
             this.UserListTabs = new DevProLauncher.Windows.Components.FixedTabControl();
@@ -76,7 +78,7 @@ namespace DevProLauncher.Windows
             this.Level1ColorBtn = new System.Windows.Forms.Button();
             this.Level3ColorBtn = new System.Windows.Forms.Button();
             this.Level4ColorBtn = new System.Windows.Forms.Button();
-            this.Level99ColorBtn = new System.Windows.Forms.Button();
+            this.BotColorBtn = new System.Windows.Forms.Button();
             this.NormalTextColorBtn = new System.Windows.Forms.Button();
             this.label8 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
@@ -98,12 +100,11 @@ namespace DevProLauncher.Windows
             this.tableLayoutPanel8 = new System.Windows.Forms.TableLayoutPanel();
             this.label2 = new System.Windows.Forms.Label();
             this.FontSize = new System.Windows.Forms.NumericUpDown();
-            this.tableLayoutPanel6 = new System.Windows.Forms.TableLayoutPanel();
-            this.UserSearch = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel5.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
+            this.tableLayoutPanel6.SuspendLayout();
             this.UsersControl.SuspendLayout();
             this.UsersTab.SuspendLayout();
             this.UserListTabs.SuspendLayout();
@@ -122,7 +123,6 @@ namespace DevProLauncher.Windows
             this.tableLayoutPanel7.SuspendLayout();
             this.tableLayoutPanel8.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.FontSize)).BeginInit();
-            this.tableLayoutPanel6.SuspendLayout();
             this.SuspendLayout();
             // 
             // UserTab
@@ -222,17 +222,6 @@ namespace DevProLauncher.Windows
             this.LeaveBtn.UseVisualStyleBackColor = true;
             this.LeaveBtn.Click += new System.EventHandler(this.LeaveBtn_Click);
             // 
-            // ChannelTabs
-            // 
-            this.ChannelTabs.Alignment = System.Windows.Forms.TabAlignment.Bottom;
-            this.ChannelTabs.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ChannelTabs.Location = new System.Drawing.Point(3, 3);
-            this.ChannelTabs.Multiline = true;
-            this.ChannelTabs.Name = "ChannelTabs";
-            this.ChannelTabs.SelectedIndex = 0;
-            this.ChannelTabs.Size = new System.Drawing.Size(690, 486);
-            this.ChannelTabs.TabIndex = 2;
-            // 
             // tableLayoutPanel3
             // 
             this.tableLayoutPanel3.ColumnCount = 1;
@@ -247,6 +236,41 @@ namespace DevProLauncher.Windows
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(215, 525);
             this.tableLayoutPanel3.TabIndex = 1;
+            // 
+            // tableLayoutPanel6
+            // 
+            this.tableLayoutPanel6.ColumnCount = 1;
+            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel6.Controls.Add(this.UserSearch, 0, 0);
+            this.tableLayoutPanel6.Location = new System.Drawing.Point(3, 495);
+            this.tableLayoutPanel6.Name = "tableLayoutPanel6";
+            this.tableLayoutPanel6.RowCount = 1;
+            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel6.Size = new System.Drawing.Size(209, 24);
+            this.tableLayoutPanel6.TabIndex = 2;
+            // 
+            // UserSearch
+            // 
+            this.UserSearch.BackColor = System.Drawing.SystemColors.ActiveCaption;
+            this.UserSearch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.UserSearch.ForeColor = System.Drawing.SystemColors.WindowFrame;
+            this.UserSearch.Location = new System.Drawing.Point(3, 3);
+            this.UserSearch.Name = "UserSearch";
+            this.UserSearch.Size = new System.Drawing.Size(203, 20);
+            this.UserSearch.TabIndex = 1;
+            this.UserSearch.Text = "Search";
+            this.UserSearch.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // ChannelTabs
+            // 
+            this.ChannelTabs.Alignment = System.Windows.Forms.TabAlignment.Bottom;
+            this.ChannelTabs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ChannelTabs.Location = new System.Drawing.Point(3, 3);
+            this.ChannelTabs.Multiline = true;
+            this.ChannelTabs.Name = "ChannelTabs";
+            this.ChannelTabs.SelectedIndex = 0;
+            this.ChannelTabs.Size = new System.Drawing.Size(690, 486);
+            this.ChannelTabs.TabIndex = 2;
             // 
             // UsersControl
             // 
@@ -603,7 +627,7 @@ namespace DevProLauncher.Windows
             this.tableLayoutPanel11.Controls.Add(this.Level1ColorBtn, 1, 5);
             this.tableLayoutPanel11.Controls.Add(this.Level3ColorBtn, 1, 4);
             this.tableLayoutPanel11.Controls.Add(this.Level4ColorBtn, 1, 3);
-            this.tableLayoutPanel11.Controls.Add(this.Level99ColorBtn, 1, 2);
+            this.tableLayoutPanel11.Controls.Add(this.BotColorBtn, 1, 2);
             this.tableLayoutPanel11.Controls.Add(this.NormalTextColorBtn, 1, 1);
             this.tableLayoutPanel11.Controls.Add(this.label8, 0, 8);
             this.tableLayoutPanel11.Controls.Add(this.label7, 0, 7);
@@ -729,15 +753,15 @@ namespace DevProLauncher.Windows
             this.Level4ColorBtn.UseVisualStyleBackColor = true;
             this.Level4ColorBtn.Click += new System.EventHandler(this.ApplyNewColor);
             // 
-            // Level99ColorBtn
+            // BotColorBtn
             // 
-            this.Level99ColorBtn.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Level99ColorBtn.Location = new System.Drawing.Point(129, 53);
-            this.Level99ColorBtn.Name = "Level99ColorBtn";
-            this.Level99ColorBtn.Size = new System.Drawing.Size(24, 19);
-            this.Level99ColorBtn.TabIndex = 30;
-            this.Level99ColorBtn.UseVisualStyleBackColor = true;
-            this.Level99ColorBtn.Click += new System.EventHandler(this.ApplyNewColor);
+            this.BotColorBtn.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BotColorBtn.Location = new System.Drawing.Point(129, 53);
+            this.BotColorBtn.Name = "BotColorBtn";
+            this.BotColorBtn.Size = new System.Drawing.Size(24, 19);
+            this.BotColorBtn.TabIndex = 30;
+            this.BotColorBtn.UseVisualStyleBackColor = true;
+            this.BotColorBtn.Click += new System.EventHandler(this.ApplyNewColor);
             // 
             // NormalTextColorBtn
             // 
@@ -796,7 +820,7 @@ namespace DevProLauncher.Windows
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(120, 25);
             this.label11.TabIndex = 14;
-            this.label11.Text = "Dev";
+            this.label11.Text = "Bot";
             this.label11.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // label12
@@ -974,30 +998,6 @@ namespace DevProLauncher.Windows
             0,
             131072});
             // 
-            // tableLayoutPanel6
-            // 
-            this.tableLayoutPanel6.ColumnCount = 1;
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel6.Controls.Add(this.UserSearch, 0, 0);
-            this.tableLayoutPanel6.Location = new System.Drawing.Point(3, 495);
-            this.tableLayoutPanel6.Name = "tableLayoutPanel6";
-            this.tableLayoutPanel6.RowCount = 1;
-            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel6.Size = new System.Drawing.Size(209, 24);
-            this.tableLayoutPanel6.TabIndex = 2;
-            // 
-            // UserSearch
-            // 
-            this.UserSearch.BackColor = System.Drawing.SystemColors.ActiveCaption;
-            this.UserSearch.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.UserSearch.ForeColor = System.Drawing.SystemColors.WindowFrame;
-            this.UserSearch.Location = new System.Drawing.Point(3, 3);
-            this.UserSearch.Name = "UserSearch";
-            this.UserSearch.Size = new System.Drawing.Size(203, 20);
-            this.UserSearch.TabIndex = 1;
-            this.UserSearch.Text = "Search";
-            this.UserSearch.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            // 
             // ChatFrm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1012,6 +1012,8 @@ namespace DevProLauncher.Windows
             this.tableLayoutPanel5.ResumeLayout(false);
             this.tableLayoutPanel5.PerformLayout();
             this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel6.ResumeLayout(false);
+            this.tableLayoutPanel6.PerformLayout();
             this.UsersControl.ResumeLayout(false);
             this.UsersTab.ResumeLayout(false);
             this.UserListTabs.ResumeLayout(false);
@@ -1034,8 +1036,6 @@ namespace DevProLauncher.Windows
             this.tableLayoutPanel8.ResumeLayout(false);
             this.tableLayoutPanel8.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.FontSize)).EndInit();
-            this.tableLayoutPanel6.ResumeLayout(false);
-            this.tableLayoutPanel6.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -1075,7 +1075,7 @@ namespace DevProLauncher.Windows
         private System.Windows.Forms.Button Level1ColorBtn;
         private System.Windows.Forms.Button Level3ColorBtn;
         private System.Windows.Forms.Button Level4ColorBtn;
-        private System.Windows.Forms.Button Level99ColorBtn;
+        private System.Windows.Forms.Button BotColorBtn;
         private System.Windows.Forms.Button NormalTextColorBtn;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
         private System.Windows.Forms.GroupBox groupBox7;

--- a/Windows/Chat_frm.cs
+++ b/Windows/Chat_frm.cs
@@ -170,7 +170,7 @@ namespace DevProLauncher.Windows
 
             BackgroundColorBtn.BackColor = Program.Config.ChatBGColor.ToColor();
             NormalTextColorBtn.BackColor = Program.Config.NormalTextColor.ToColor();
-            Level99ColorBtn.BackColor = Program.Config.Level99Color.ToColor();
+            BotColorBtn.BackColor = Program.Config.BotColor.ToColor();
             Level4ColorBtn.BackColor = Program.Config.Level4Color.ToColor();
             Level3ColorBtn.BackColor = Program.Config.Level3Color.ToColor();
             Level1ColorBtn.BackColor = Program.Config.Level1Color.ToColor();
@@ -218,7 +218,7 @@ namespace DevProLauncher.Windows
 
             label13.Text = lang.chatoptionsLblChatBackground;
             label12.Text = lang.chatoptionsLblNormalText;
-            label11.Text = lang.chatoptionsLblLevel99;
+            label11.Text = lang.chatoptionsLblLevel98;
             //label10.Text = lang.chatoptionsLblLevel2;
             label9.Text = lang.chatoptionsLblLevel1;
             label4.Text = lang.chatoptionsLblNormalUser;
@@ -834,8 +834,8 @@ namespace DevProLauncher.Windows
                     case "Level4ColorBtn":
                         Program.Config.Level4Color = new SerializableColor(selectcolor.Color);
                         break;
-                    case "Level99ColorBtn":
-                        Program.Config.Level99Color = new SerializableColor(selectcolor.Color);
+                    case "BotColorBtn":
+                        Program.Config.BotColor = new SerializableColor(selectcolor.Color);
                         break;
                     case "NormalTextColorBtn":
                         Program.Config.NormalTextColor = new SerializableColor(selectcolor.Color);

--- a/Windows/Main_frm.cs
+++ b/Windows/Main_frm.cs
@@ -136,7 +136,7 @@ namespace DevProLauncher.Windows
 
         private void CheckConnection(object sender, EventArgs e)
         {
-            if (!Program.banned)
+            if (!Program.ChatServer.IsUserBanned)
             {
                 if (!Program.ChatServer.Connected())
                 {

--- a/Windows/Main_frm.cs
+++ b/Windows/Main_frm.cs
@@ -136,24 +136,27 @@ namespace DevProLauncher.Windows
 
         private void CheckConnection(object sender, EventArgs e)
         {
-            if (!Program.ChatServer.Connected())
+            if (!Program.banned)
             {
-                var connectionCheck = (Timer)sender;
-                Hide();
-                connectionCheck.Enabled = false;
-                if (MessageBox.Show(!string.IsNullOrEmpty(Program.ChatServer.ServerKickBanMessage) ? Program.ChatServer.ServerKickBanMessage: "Disconnected from server.\n\r Do you want to restart DevPro ?", "Server", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                if (!Program.ChatServer.Connected())
                 {
-                    var process = new Process();
-                    var startInfos = new ProcessStartInfo(Application.ExecutablePath, "-r");
-                    process.StartInfo = startInfos;
-                    process.Start(); 
-                    Application.Exit(); 
-                }
-                else
-                {
-                    Application.Exit();
-                }
+                    var connectionCheck = (Timer)sender;
+                    Hide();
+                    connectionCheck.Enabled = false;
+                    if (MessageBox.Show(!string.IsNullOrEmpty(Program.ChatServer.ServerKickBanMessage) ? Program.ChatServer.ServerKickBanMessage : "Disconnected from server.\n\r Do you want to restart DevPro ?", "Server", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                    {
+                        var process = new Process();
+                        var startInfos = new ProcessStartInfo(Application.ExecutablePath, "-r");
+                        process.StartInfo = startInfos;
+                        process.Start();
+                        Application.Exit();
+                    }
+                    else
+                    {
+                        Application.Exit();
+                    }
 
+                }
             }
         }
 

--- a/Windows/Main_frm.cs
+++ b/Windows/Main_frm.cs
@@ -141,13 +141,13 @@ namespace DevProLauncher.Windows
                 var connectionCheck = (Timer)sender;
                 Hide();
                 connectionCheck.Enabled = false;
-                if (MessageBox.Show(!string.IsNullOrEmpty(Program.ChatServer.ServerKickBanMessage) ? Program.ChatServer.ServerKickBanMessage: "Disconnected from server.", "Server", MessageBoxButtons.OK) == DialogResult.OK)
+                if (MessageBox.Show(!string.IsNullOrEmpty(Program.ChatServer.ServerKickBanMessage) ? Program.ChatServer.ServerKickBanMessage: "Disconnected from server.\n\r Do you want to restart DevPro ?", "Server", MessageBoxButtons.YesNo) == DialogResult.Yes)
                 {
                     var process = new Process();
                     var startInfos = new ProcessStartInfo(Application.ExecutablePath, "-r");
                     process.StartInfo = startInfos;
-                    process.Start();
-                    Application.Exit();
+                    process.Start(); 
+                    Application.Exit(); 
                 }
                 else
                 {


### PR DESCRIPTION
The Kick Ban message box works fine now.
In ChatHelper, in the method writeText, verify if the text is null for
escape bug when command like getbanlist is use even if there is not user
ban.