### PR TITLE
Catch exceptions when opening an URL to prevent crashes

### DIFF
--- a/Windows/Components/ChatWindow.cs
+++ b/Windows/Components/ChatWindow.cs
@@ -50,7 +50,14 @@ namespace DevProLauncher.Windows.Components
 
         private void ChatLog_LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            Process.Start(e.LinkText);
+            try
+            {
+                Process.Start(e.LinkText);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
 
         public void ApplyNewSettings()


### PR DESCRIPTION
Too many users are experiencing crashes when clicking on a link. It can be because the URL is malformed, because the browser is laggy or buggy...

Example : a click on `\\o` will throw an exception and crash the launcher.